### PR TITLE
Add gdal to cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Afterwards, compile:
 
     mkdir build
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Release ..
+    cmake -DCMAKE_BUILD_TYPE=Release -DUSE_GDAL=ON ..
     make -j 4 #Set to number of CPUs for a faster compilation
 
 Run with:


### PR DESCRIPTION
It seems that gdal is now required for a successful cmake